### PR TITLE
Cmapi2 457

### DIFF
--- a/bip-framework-libraries/src/main/java/gov/va/bip/framework/messages/MessageKeys.java
+++ b/bip-framework-libraries/src/main/java/gov/va/bip/framework/messages/MessageKeys.java
@@ -64,7 +64,7 @@ public enum MessageKeys implements MessageKey {
 	/** MethodArgumentTypeMismatchException; {0} = argument name; {1} = expected class name */
 	BIP_GLOBAL_REST_API_TYPE_MISMATCH("bip.framework.global.rest.api.type.mismatch", "API argument type could not be resolved."),
 	/** ConstraintViolationException; {0} = bean class name; {1} = property name; {2} = violation message */
-	BIP_GLBOAL_VALIDATOR_CONSTRAINT_VIOLATION("bip.framework.global.validator.constraint.violation",
+	BIP_GLOBAL_VALIDATOR_CONSTRAINT_VIOLATION("bip.framework.global.validator.constraint.violation",
 			"Validation constraint was violated."),
 
 	/** JAXB Marshaller configuration failed; no args */

--- a/bip-framework-libraries/src/main/java/gov/va/bip/framework/rest/exception/BipRestGlobalExceptionHandler.java
+++ b/bip-framework-libraries/src/main/java/gov/va/bip/framework/rest/exception/BipRestGlobalExceptionHandler.java
@@ -17,7 +17,7 @@ import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.http.converter.HttpMessageConversionException;
 import org.springframework.validation.FieldError;
 import org.springframework.validation.ObjectError;
 import org.springframework.web.HttpMediaTypeNotSupportedException;
@@ -91,12 +91,12 @@ public class BipRestGlobalExceptionHandler extends BaseHttpProviderPointcuts {
 		 */
 		String causeClassname = (ex.getCause() == null
 				? null
-						: ex.getCause().getClass().getName() + ":");
+				: ex.getCause().getClass().getName() + ":");
 
 		/* Scrub any occurrances of cause classname from exception message */
 		String msg = (causeClassname != null && StringUtils.isNotBlank(ex.getMessage())
 				? ex.getMessage().replaceAll(causeClassname, "")
-						: ex.getMessage());
+				: ex.getMessage());
 
 		/* Final check for empty */
 		if (StringUtils.isBlank(msg)) {
@@ -421,15 +421,15 @@ public class BipRestGlobalExceptionHandler extends BaseHttpProviderPointcuts {
 	 *
 	 * @param req
 	 *            the req
-	 * @param httpMessageNotReadableException
-	 *            the http message not readable exception
+	 * @param HttpMessageConversionException
+	 *            the http message not readable or writable exception
 	 * @return the response entity
 	 */
-	@ExceptionHandler(value = HttpMessageNotReadableException.class)
+	@ExceptionHandler(value = HttpMessageConversionException.class)
 	@ResponseStatus(value = HttpStatus.BAD_REQUEST)
-	public final ResponseEntity<Object> handleHttpMessageNotReadableException(final HttpServletRequest req,
-			final HttpMessageNotReadableException httpMessageNotReadableException) {
-		return jsonExceptionHandler(httpMessageNotReadableException);
+	public final ResponseEntity<Object> handleHttpMessageConversionException(final HttpServletRequest req,
+			final HttpMessageConversionException httpHttpMessageConversionException) {
+		return jsonExceptionHandler(httpHttpMessageConversionException);
 	}
 
 	/**
@@ -441,9 +441,9 @@ public class BipRestGlobalExceptionHandler extends BaseHttpProviderPointcuts {
 	 * @return the response entity
 	 */
 	private ResponseEntity<Object> jsonExceptionHandler(
-			final HttpMessageNotReadableException httpMessageNotReadableException) {
+			final HttpMessageConversionException httpHttpMessageConversionException) {
 		String jsonOriginalMessage = StringUtils.EMPTY;
-		final Throwable mostSpecificCause = httpMessageNotReadableException.getMostSpecificCause();
+		final Throwable mostSpecificCause = httpHttpMessageConversionException.getMostSpecificCause();
 		if (mostSpecificCause instanceof JsonParseException) {
 			JsonParseException jpe = (JsonParseException) mostSpecificCause;
 			jsonOriginalMessage = jpe.getOriginalMessage();
@@ -458,7 +458,7 @@ public class BipRestGlobalExceptionHandler extends BaseHttpProviderPointcuts {
 			return new ResponseEntity<>(apiError, HttpHeadersUtil.buildHttpHeadersForError(), HttpStatus.BAD_REQUEST);
 
 		} else {
-			return standardHandler(httpMessageNotReadableException, MessageKeys.NO_KEY, MessageSeverity.ERROR,
+			return standardHandler(httpHttpMessageConversionException, MessageKeys.NO_KEY, MessageSeverity.ERROR,
 					HttpStatus.BAD_REQUEST);
 		}
 	}

--- a/bip-framework-libraries/src/main/java/gov/va/bip/framework/rest/exception/BipRestGlobalExceptionHandler.java
+++ b/bip-framework-libraries/src/main/java/gov/va/bip/framework/rest/exception/BipRestGlobalExceptionHandler.java
@@ -443,14 +443,14 @@ public class BipRestGlobalExceptionHandler extends BaseHttpProviderPointcuts {
 	private ResponseEntity<Object> jsonExceptionHandler(
 			final HttpMessageNotReadableException httpMessageNotReadableException) {
 		String jsonOriginalMessage = StringUtils.EMPTY;
-		if (httpMessageNotReadableException.getMostSpecificCause() instanceof JsonParseException) {
-			JsonParseException jpe = (JsonParseException) httpMessageNotReadableException.getMostSpecificCause();
+		final Throwable mostSpecificCause = httpMessageNotReadableException.getMostSpecificCause();
+		if (mostSpecificCause instanceof JsonParseException) {
+			JsonParseException jpe = (JsonParseException) mostSpecificCause;
 			jsonOriginalMessage = jpe.getOriginalMessage();
-		} else if (httpMessageNotReadableException.getMostSpecificCause() instanceof JsonMappingException) {
-			JsonMappingException jme = (JsonMappingException) httpMessageNotReadableException.getMostSpecificCause();
+		} else if (mostSpecificCause instanceof JsonMappingException) {
+			JsonMappingException jme = (JsonMappingException) mostSpecificCause;
 			jsonOriginalMessage = jme.getOriginalMessage();
 		}
-
 		if (!StringUtils.isEmpty(jsonOriginalMessage)) {
 			final ProviderResponse apiError = new ProviderResponse();
 			apiError.addMessage(MessageSeverity.ERROR, MessageKeys.NO_KEY.getKey(),

--- a/bip-framework-libraries/src/test/java/gov/va/bip/framework/rest/exception/BipRestGlobalExceptionHandlerTest.java
+++ b/bip-framework-libraries/src/test/java/gov/va/bip/framework/rest/exception/BipRestGlobalExceptionHandlerTest.java
@@ -45,6 +45,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.http.converter.HttpMessageNotWritableException;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.test.context.ContextConfiguration;
@@ -155,7 +156,7 @@ public class BipRestGlobalExceptionHandlerTest extends AbstractBaseLogTester {
 	@SuppressWarnings("unchecked")
 	@Test
 	public void logInfoTest() throws NoSuchMethodException, SecurityException, IllegalAccessException, IllegalArgumentException,
-	InvocationTargetException {
+			InvocationTargetException {
 		Method logMethod = bipRestGlobalExceptionHandler.getClass().getDeclaredMethod("log", Exception.class, MessageKey.class,
 				MessageSeverity.class, HttpStatus.class, String[].class);
 		logMethod.setAccessible(true);
@@ -171,7 +172,7 @@ public class BipRestGlobalExceptionHandlerTest extends AbstractBaseLogTester {
 	@SuppressWarnings("unchecked")
 	@Test
 	public void logDebugTest() throws NoSuchMethodException, SecurityException, IllegalAccessException, IllegalArgumentException,
-	InvocationTargetException {
+			InvocationTargetException {
 		Method logMethod = bipRestGlobalExceptionHandler.getClass().getDeclaredMethod("log", Exception.class, MessageKey.class,
 				MessageSeverity.class, HttpStatus.class, String[].class);
 		logMethod.setAccessible(true);
@@ -187,7 +188,7 @@ public class BipRestGlobalExceptionHandlerTest extends AbstractBaseLogTester {
 	@SuppressWarnings("unchecked")
 	@Test
 	public void logWarnTest() throws NoSuchMethodException, SecurityException, IllegalAccessException, IllegalArgumentException,
-	InvocationTargetException {
+			InvocationTargetException {
 		Method logMethod = bipRestGlobalExceptionHandler.getClass().getDeclaredMethod("log", Exception.class, MessageKey.class,
 				MessageSeverity.class, HttpStatus.class, String[].class);
 		logMethod.setAccessible(true);
@@ -393,7 +394,18 @@ public class BipRestGlobalExceptionHandlerTest extends AbstractBaseLogTester {
 					}
 				});
 
-		ResponseEntity<Object> response = bipRestGlobalExceptionHandler.handleHttpMessageNotReadableException(req, ex);
+		ResponseEntity<Object> response = bipRestGlobalExceptionHandler.handleHttpMessageConversionException(req, ex);
+		assertTrue(response.getStatusCode().equals(HttpStatus.BAD_REQUEST));
+	}
+
+	@Test
+	public void handleHttpMessageNotWritableExceptionTest() {
+		HttpServletRequest req = mock(HttpServletRequest.class);
+
+		HttpMessageNotWritableException ex =
+				new HttpMessageNotWritableException("test msg", new Exception("wrapped message"));
+
+		ResponseEntity<Object> response = bipRestGlobalExceptionHandler.handleHttpMessageConversionException(req, ex);
 		assertTrue(response.getStatusCode().equals(HttpStatus.BAD_REQUEST));
 	}
 
@@ -402,22 +414,23 @@ public class BipRestGlobalExceptionHandlerTest extends AbstractBaseLogTester {
 		HttpServletRequest req = mock(HttpServletRequest.class);
 
 		HttpMessageNotReadableException ex =
-				new HttpMessageNotReadableException("test msg", new JsonParseException(null, "wrapped json parse exception message"), new HttpInputMessage() {
+				new HttpMessageNotReadableException("test msg", new JsonParseException(null, "wrapped json parse exception message"),
+						new HttpInputMessage() {
 
-					@Override
-					public HttpHeaders getHeaders() {
-						HttpHeaders headers = new HttpHeaders();
-						headers.setContentType(MediaType.TEXT_PLAIN);
-						return headers;
-					}
+							@Override
+							public HttpHeaders getHeaders() {
+								HttpHeaders headers = new HttpHeaders();
+								headers.setContentType(MediaType.TEXT_PLAIN);
+								return headers;
+							}
 
-					@Override
-					public InputStream getBody() throws IOException {
-						return new ByteArrayInputStream("test body".getBytes());
-					}
-				});
+							@Override
+							public InputStream getBody() throws IOException {
+								return new ByteArrayInputStream("test body".getBytes());
+							}
+						});
 
-		ResponseEntity<Object> response = bipRestGlobalExceptionHandler.handleHttpMessageNotReadableException(req, ex);
+		ResponseEntity<Object> response = bipRestGlobalExceptionHandler.handleHttpMessageConversionException(req, ex);
 		assertTrue(response.getStatusCode().equals(HttpStatus.BAD_REQUEST));
 		assertTrue(response.getBody() instanceof ProviderResponse);
 		try {
@@ -434,22 +447,23 @@ public class BipRestGlobalExceptionHandlerTest extends AbstractBaseLogTester {
 		HttpServletRequest req = mock(HttpServletRequest.class);
 
 		HttpMessageNotReadableException ex =
-				new HttpMessageNotReadableException("test msg", new JsonMappingException(null, "wrapped json mapping exception message"), new HttpInputMessage() {
+				new HttpMessageNotReadableException("test msg",
+						new JsonMappingException(null, "wrapped json mapping exception message"), new HttpInputMessage() {
 
-					@Override
-					public HttpHeaders getHeaders() {
-						HttpHeaders headers = new HttpHeaders();
-						headers.setContentType(MediaType.TEXT_PLAIN);
-						return headers;
-					}
+							@Override
+							public HttpHeaders getHeaders() {
+								HttpHeaders headers = new HttpHeaders();
+								headers.setContentType(MediaType.TEXT_PLAIN);
+								return headers;
+							}
 
-					@Override
-					public InputStream getBody() throws IOException {
-						return new ByteArrayInputStream("test body".getBytes());
-					}
-				});
+							@Override
+							public InputStream getBody() throws IOException {
+								return new ByteArrayInputStream("test body".getBytes());
+							}
+						});
 
-		ResponseEntity<Object> response = bipRestGlobalExceptionHandler.handleHttpMessageNotReadableException(req, ex);
+		ResponseEntity<Object> response = bipRestGlobalExceptionHandler.handleHttpMessageConversionException(req, ex);
 		assertTrue(response.getStatusCode().equals(HttpStatus.BAD_REQUEST));
 		assertTrue(response.getBody() instanceof ProviderResponse);
 		try {

--- a/bip-framework-libraries/src/test/java/gov/va/bip/framework/rest/exception/BipRestGlobalExceptionHandlerTest.java
+++ b/bip-framework-libraries/src/test/java/gov/va/bip/framework/rest/exception/BipRestGlobalExceptionHandlerTest.java
@@ -62,7 +62,9 @@ import org.springframework.web.method.annotation.MethodArgumentTypeMismatchExcep
 import org.springframework.web.servlet.NoHandlerFoundException;
 
 import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 import gov.va.bip.framework.AbstractBaseLogTester;
 import gov.va.bip.framework.exception.BipExceptionData;
@@ -74,6 +76,7 @@ import gov.va.bip.framework.log.BipLoggerFactory;
 import gov.va.bip.framework.messages.MessageKey;
 import gov.va.bip.framework.messages.MessageKeys;
 import gov.va.bip.framework.messages.MessageSeverity;
+import gov.va.bip.framework.rest.provider.ProviderResponse;
 import gov.va.bip.framework.shared.sanitize.SanitizerException;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -399,7 +402,7 @@ public class BipRestGlobalExceptionHandlerTest extends AbstractBaseLogTester {
 		HttpServletRequest req = mock(HttpServletRequest.class);
 
 		HttpMessageNotReadableException ex =
-				new HttpMessageNotReadableException("test msg", new JsonParseException(null, "wrapped message"), new HttpInputMessage() {
+				new HttpMessageNotReadableException("test msg", new JsonParseException(null, "wrapped json parse exception message"), new HttpInputMessage() {
 
 					@Override
 					public HttpHeaders getHeaders() {
@@ -416,6 +419,14 @@ public class BipRestGlobalExceptionHandlerTest extends AbstractBaseLogTester {
 
 		ResponseEntity<Object> response = bipRestGlobalExceptionHandler.handleHttpMessageNotReadableException(req, ex);
 		assertTrue(response.getStatusCode().equals(HttpStatus.BAD_REQUEST));
+		assertTrue(response.getBody() instanceof ProviderResponse);
+		try {
+			ObjectMapper objectMapper = new ObjectMapper();
+			String responseBody = objectMapper.writeValueAsString(response.getBody());
+			assertTrue(responseBody.contains("wrapped json parse exception message"));
+		} catch (JsonProcessingException e) {
+			fail("Error processing the response body");
+		}
 	}
 
 	@Test
@@ -423,7 +434,7 @@ public class BipRestGlobalExceptionHandlerTest extends AbstractBaseLogTester {
 		HttpServletRequest req = mock(HttpServletRequest.class);
 
 		HttpMessageNotReadableException ex =
-				new HttpMessageNotReadableException("test msg", new JsonMappingException(null, "wrapped message"), new HttpInputMessage() {
+				new HttpMessageNotReadableException("test msg", new JsonMappingException(null, "wrapped json mapping exception message"), new HttpInputMessage() {
 
 					@Override
 					public HttpHeaders getHeaders() {
@@ -440,6 +451,14 @@ public class BipRestGlobalExceptionHandlerTest extends AbstractBaseLogTester {
 
 		ResponseEntity<Object> response = bipRestGlobalExceptionHandler.handleHttpMessageNotReadableException(req, ex);
 		assertTrue(response.getStatusCode().equals(HttpStatus.BAD_REQUEST));
+		assertTrue(response.getBody() instanceof ProviderResponse);
+		try {
+			ObjectMapper objectMapper = new ObjectMapper();
+			String responseBody = objectMapper.writeValueAsString(response.getBody());
+			assertTrue(responseBody.contains("wrapped json mapping exception message"));
+		} catch (JsonProcessingException e) {
+			fail("Error processing the response body");
+		}
 	}
 
 	@Test

--- a/bip-framework-libraries/src/test/java/gov/va/bip/framework/rest/exception/BipRestGlobalExceptionHandlerTest.java
+++ b/bip-framework-libraries/src/test/java/gov/va/bip/framework/rest/exception/BipRestGlobalExceptionHandlerTest.java
@@ -61,6 +61,9 @@ import org.springframework.web.context.request.ServletRequestAttributes;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 import org.springframework.web.servlet.NoHandlerFoundException;
 
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.databind.JsonMappingException;
+
 import gov.va.bip.framework.AbstractBaseLogTester;
 import gov.va.bip.framework.exception.BipExceptionData;
 import gov.va.bip.framework.exception.BipPartnerException;
@@ -373,6 +376,54 @@ public class BipRestGlobalExceptionHandlerTest extends AbstractBaseLogTester {
 
 		HttpMessageNotReadableException ex =
 				new HttpMessageNotReadableException("test msg", new Exception("wrapped message"), new HttpInputMessage() {
+
+					@Override
+					public HttpHeaders getHeaders() {
+						HttpHeaders headers = new HttpHeaders();
+						headers.setContentType(MediaType.TEXT_PLAIN);
+						return headers;
+					}
+
+					@Override
+					public InputStream getBody() throws IOException {
+						return new ByteArrayInputStream("test body".getBytes());
+					}
+				});
+
+		ResponseEntity<Object> response = bipRestGlobalExceptionHandler.handleHttpMessageNotReadableException(req, ex);
+		assertTrue(response.getStatusCode().equals(HttpStatus.BAD_REQUEST));
+	}
+
+	@Test
+	public void handleHttpMessageNotReadableJsonParseExceptionTest() {
+		HttpServletRequest req = mock(HttpServletRequest.class);
+
+		HttpMessageNotReadableException ex =
+				new HttpMessageNotReadableException("test msg", new JsonParseException(null, "wrapped message"), new HttpInputMessage() {
+
+					@Override
+					public HttpHeaders getHeaders() {
+						HttpHeaders headers = new HttpHeaders();
+						headers.setContentType(MediaType.TEXT_PLAIN);
+						return headers;
+					}
+
+					@Override
+					public InputStream getBody() throws IOException {
+						return new ByteArrayInputStream("test body".getBytes());
+					}
+				});
+
+		ResponseEntity<Object> response = bipRestGlobalExceptionHandler.handleHttpMessageNotReadableException(req, ex);
+		assertTrue(response.getStatusCode().equals(HttpStatus.BAD_REQUEST));
+	}
+
+	@Test
+	public void handleHttpMessageNotReadableJsonMappingExceptionTest() {
+		HttpServletRequest req = mock(HttpServletRequest.class);
+
+		HttpMessageNotReadableException ex =
+				new HttpMessageNotReadableException("test msg", new JsonMappingException(null, "wrapped message"), new HttpInputMessage() {
 
 					@Override
 					public HttpHeaders getHeaders() {


### PR DESCRIPTION
 1.  Handle specific reasons of HttpMessageNotReadableException
 1.  Refactored variable naming to spell it correctly