### PR TITLE
AF 625

### DIFF
--- a/bip-framework-libraries/src/main/java/gov/va/bip/framework/messages/MessageKeys.java
+++ b/bip-framework-libraries/src/main/java/gov/va/bip/framework/messages/MessageKeys.java
@@ -77,6 +77,8 @@ public enum MessageKeys implements MessageKey {
 
 	/** JWT token is invalid; no args */
 	BIP_SECURITY_TOKEN_INVALID("bip.framework.security.token.invalid", "Invalid Token."),
+	BIP_SECURITY_TOKEN_INVALID_REQ_PARAM_MISSING("bip.framework.security.token.invalid.req.param.missing",
+			"Invalid Token. Parameter(s) Missing. Required JWT parameters configured {0}"),
 	/** JWT token cannot be blank; no args */
 	BIP_SECURITY_TOKEN_BLANK("bip.framework.security.token.blank", "No JWT Token in Header."),
 	/**

--- a/bip-framework-libraries/src/main/java/gov/va/bip/framework/rest/exception/BipRestGlobalExceptionHandler.java
+++ b/bip-framework-libraries/src/main/java/gov/va/bip/framework/rest/exception/BipRestGlobalExceptionHandler.java
@@ -49,6 +49,7 @@ import gov.va.bip.framework.messages.MessageKeys;
 import gov.va.bip.framework.messages.MessageSeverity;
 import gov.va.bip.framework.rest.provider.ProviderResponse;
 import gov.va.bip.framework.rest.provider.aspect.BaseHttpProviderPointcuts;
+import gov.va.bip.framework.security.jwt.JwtAuthenticationException;
 import gov.va.bip.framework.shared.sanitize.SanitizerException;
 import gov.va.bip.framework.util.HttpHeadersUtil;
 
@@ -237,6 +238,20 @@ public class BipRestGlobalExceptionHandler extends BaseHttpProviderPointcuts {
 	@ResponseStatus(value = HttpStatus.BAD_REQUEST)
 	public final ResponseEntity<Object> handleBipPartnerRuntimeException(final HttpServletRequest req,
 			final BipPartnerRuntimeException ex) {
+		return standardHandler(ex, HttpStatus.BAD_REQUEST);
+	}
+	
+	/**
+	 * Handle JwtAuthenticationException.
+	 *
+	 * @param req the req
+	 * @param ex the ex
+	 * @return the response entity
+	 */
+	@ExceptionHandler(value = JwtAuthenticationException.class)
+	@ResponseStatus(value = HttpStatus.BAD_REQUEST)
+	public final ResponseEntity<Object> handleJwtAuthenticationException(final HttpServletRequest req,
+			final JwtAuthenticationException ex) {
 		return standardHandler(ex, HttpStatus.BAD_REQUEST);
 	}
 

--- a/bip-framework-libraries/src/main/java/gov/va/bip/framework/rest/exception/BipRestGlobalExceptionHandler.java
+++ b/bip-framework-libraries/src/main/java/gov/va/bip/framework/rest/exception/BipRestGlobalExceptionHandler.java
@@ -249,10 +249,9 @@ public class BipRestGlobalExceptionHandler extends BaseHttpProviderPointcuts {
 	 * @return the response entity
 	 */
 	@ExceptionHandler(value = JwtAuthenticationException.class)
-	@ResponseStatus(value = HttpStatus.BAD_REQUEST)
 	public final ResponseEntity<Object> handleJwtAuthenticationException(final HttpServletRequest req,
 			final JwtAuthenticationException ex) {
-		return standardHandler(ex, HttpStatus.BAD_REQUEST);
+		return standardHandler(ex, ex.getExceptionData().getStatus());
 	}
 
 	/**

--- a/bip-framework-libraries/src/main/java/gov/va/bip/framework/security/jwt/JwtAuthenticationProvider.java
+++ b/bip-framework-libraries/src/main/java/gov/va/bip/framework/security/jwt/JwtAuthenticationProvider.java
@@ -2,6 +2,7 @@ package gov.va.bip.framework.security.jwt;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.util.Arrays;
 
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Value;
@@ -51,7 +52,13 @@ public class JwtAuthenticationProvider extends AbstractUserDetailsAuthentication
 		final String token = authenticationToken.getToken();// pass this for verification
 
 		final PersonTraits person = parser.parseJwt(token);
-		if ((person == null) || !isPersonTraitsValid(person, jwtTokenRequiredParameterList)) {
+		
+		if (!isPersonTraitsValid(person, jwtTokenRequiredParameterList)) {
+			throw new JwtAuthenticationException(MessageKeys.BIP_SECURITY_TOKEN_INVALID_REQ_PARAM_MISSING,
+					MessageSeverity.ERROR, HttpStatus.BAD_REQUEST, Arrays.toString(jwtTokenRequiredParameterList));
+		}
+		
+		if (person == null) {
 			throw new JwtAuthenticationException(MessageKeys.BIP_SECURITY_TOKEN_INVALID,
 					MessageSeverity.ERROR, HttpStatus.BAD_REQUEST);
 		}
@@ -66,6 +73,10 @@ public class JwtAuthenticationProvider extends AbstractUserDetailsAuthentication
 		boolean isValid = true;
 		for (String parameter : jwtTokenRequiredParameterList) {
 			isValid = checkIfEachParameterIsValid(person, parameter);
+			// check if the parameter is invalid and return immediately
+			if(!isValid) {
+				return isValid;
+			}
 		}
 
 		return isValid;

--- a/bip-framework-libraries/src/main/java/gov/va/bip/framework/security/jwt/JwtAuthenticationProvider.java
+++ b/bip-framework-libraries/src/main/java/gov/va/bip/framework/security/jwt/JwtAuthenticationProvider.java
@@ -52,15 +52,15 @@ public class JwtAuthenticationProvider extends AbstractUserDetailsAuthentication
 		final String token = authenticationToken.getToken();// pass this for verification
 
 		final PersonTraits person = parser.parseJwt(token);
-		
-		if (!isPersonTraitsValid(person, jwtTokenRequiredParameterList)) {
-			throw new JwtAuthenticationException(MessageKeys.BIP_SECURITY_TOKEN_INVALID_REQ_PARAM_MISSING,
-					MessageSeverity.ERROR, HttpStatus.BAD_REQUEST, Arrays.toString(jwtTokenRequiredParameterList));
-		}
-		
+
 		if (person == null) {
 			throw new JwtAuthenticationException(MessageKeys.BIP_SECURITY_TOKEN_INVALID,
 					MessageSeverity.ERROR, HttpStatus.BAD_REQUEST);
+		}
+
+		if (!isPersonTraitsValid(person, jwtTokenRequiredParameterList)) {
+			throw new JwtAuthenticationException(MessageKeys.BIP_SECURITY_TOKEN_INVALID_REQ_PARAM_MISSING,
+					MessageSeverity.ERROR, HttpStatus.BAD_REQUEST, Arrays.toString(jwtTokenRequiredParameterList));
 		}
 		return person;
 	}

--- a/bip-framework-libraries/src/main/java/gov/va/bip/framework/security/util/GenerateToken.java
+++ b/bip-framework-libraries/src/main/java/gov/va/bip/framework/security/util/GenerateToken.java
@@ -78,8 +78,8 @@ public class GenerateToken {
 		}
 
 		if (!isPersonTraitsValid(personTraits, jwtTokenRequiredParameterList)) {
-			throw new JwtAuthenticationException(MessageKeys.BIP_SECURITY_TOKEN_INVALID,
-					MessageSeverity.ERROR, HttpStatus.BAD_REQUEST);
+			throw new JwtAuthenticationException(MessageKeys.BIP_SECURITY_TOKEN_INVALID_REQ_PARAM_MISSING,
+					MessageSeverity.ERROR, HttpStatus.BAD_REQUEST, Arrays.toString(jwtTokenRequiredParameterList));
 		}
 
 		return Jwts.builder()

--- a/bip-framework-libraries/src/test/java/gov/va/bip/framework/rest/exception/BipRestGlobalExceptionHandlerTest.java
+++ b/bip-framework-libraries/src/test/java/gov/va/bip/framework/rest/exception/BipRestGlobalExceptionHandlerTest.java
@@ -79,6 +79,7 @@ import gov.va.bip.framework.messages.MessageKey;
 import gov.va.bip.framework.messages.MessageKeys;
 import gov.va.bip.framework.messages.MessageSeverity;
 import gov.va.bip.framework.rest.provider.ProviderResponse;
+import gov.va.bip.framework.security.jwt.JwtAuthenticationException;
 import gov.va.bip.framework.shared.sanitize.SanitizerException;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -599,6 +600,15 @@ public class BipRestGlobalExceptionHandlerTest extends AbstractBaseLogTester {
 		BipPartnerException ex = new BipPartnerException(TEST_KEY, MessageSeverity.ERROR, HttpStatus.BAD_REQUEST);
 		ResponseEntity<Object> response =
 				ReflectionTestUtils.invokeMethod(bipRestGlobalExceptionHandler, "handleBipPartnerCheckedException", req, ex);
+		assertTrue(response.getStatusCode().equals(HttpStatus.BAD_REQUEST));
+	}
+	
+	@Test
+	public void handleJwtAuthenticationExceptionTest() {
+		HttpServletRequest req = mock(HttpServletRequest.class);
+		JwtAuthenticationException ex = new JwtAuthenticationException(TEST_KEY, MessageSeverity.ERROR, HttpStatus.BAD_REQUEST);
+		ResponseEntity<Object> response =
+				ReflectionTestUtils.invokeMethod(bipRestGlobalExceptionHandler, "handleJwtAuthenticationException", req, ex);
 		assertTrue(response.getStatusCode().equals(HttpStatus.BAD_REQUEST));
 	}
 

--- a/bip-framework-libraries/src/test/java/gov/va/bip/framework/security/jwt/JwtAuthenticationProviderTest.java
+++ b/bip-framework-libraries/src/test/java/gov/va/bip/framework/security/jwt/JwtAuthenticationProviderTest.java
@@ -19,6 +19,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import gov.va.bip.framework.security.PersonTraits;
 import gov.va.bip.framework.security.config.BipSecurityTestConfig;
@@ -131,5 +132,27 @@ public class JwtAuthenticationProviderTest {
 		PersonTraits person = new PersonTraits();
 		person.setFirstName("string");
 		assertFalse(JwtAuthenticationProvider.isPersonTraitsValid(person, new String[] { "testText" }));
+	}
+	
+	/**
+	 * Test of retrieveUser method, of class JwtAuthenticationProvider.
+	 */
+	@Test (expected = JwtAuthenticationException.class)
+	public void testRetrieveUserWithReqParamException() {
+		final String username = "jdoe";
+		final Person person = new Person();
+		person.setFirstName("john");
+		person.setLastName("doe");
+		person.setCorrelationIds(Arrays.asList(new String[] { "1012832469V956223^NI^200M^USVHA^P", "796046489^PI^200BRLS^USVBA^A",
+				"600071516^PI^200CORP^USVBA^A", "1040626995^NI^200DOD^USDOD^A", "796046489^SS" }));
+		final String token = tokenResource.getToken(person);
+
+		final JwtAuthenticationToken authentication = new JwtAuthenticationToken(token);
+		final JwtParser parser = new JwtParser(jwtAuthenticationProperties);
+		final JwtAuthenticationProvider instance = new JwtAuthenticationProvider(parser);
+		String[] jwtTokenRequiredParameterList = {"middleName"};
+		ReflectionTestUtils.setField(instance, "jwtTokenRequiredParameterList", jwtTokenRequiredParameterList);
+		final UserDetails result = instance.retrieveUser(username, authentication);
+		assertNotNull(result);
 	}
 }

--- a/bip-framework-libraries/src/test/java/gov/va/bip/framework/security/jwt/JwtAuthenticationProviderTest.java
+++ b/bip-framework-libraries/src/test/java/gov/va/bip/framework/security/jwt/JwtAuthenticationProviderTest.java
@@ -53,8 +53,9 @@ public class JwtAuthenticationProviderTest {
 		final Person person = new Person();
 		person.setFirstName("john");
 		person.setLastName("doe");
-		person.setCorrelationIds(Arrays.asList(new String[] { "1012832469V956223^NI^200M^USVHA^P", "796046489^PI^200BRLS^USVBA^A",
-				"600071516^PI^200CORP^USVBA^A", "1040626995^NI^200DOD^USDOD^A", "796046489^SS" }));
+		person.setCorrelationIds(
+				Arrays.asList(new String[] { "1012832469V956223^NI^200M^USVHA^P", "796046489^PI^200BRLS^USVBA^A",
+						"600071516^PI^200CORP^USVBA^A", "1040626995^NI^200DOD^USDOD^A", "796046489^SS" }));
 		final String token = tokenResource.getToken(person);
 
 		final JwtAuthenticationToken authentication = new JwtAuthenticationToken(token);
@@ -70,8 +71,9 @@ public class JwtAuthenticationProviderTest {
 		final Person person = new Person();
 		person.setFirstName("john");
 		person.setLastName("doe");
-		person.setCorrelationIds(Arrays.asList(new String[] { "1012832469V956223^NI^200M^USVHA^P", "796046489^PI^200BRLS^USVBA^A",
-				"600071516^PI^200CORP^USVBA^A", "1040626995^NI^200DOD^USDOD^A", "796046489^SS" }));
+		person.setCorrelationIds(
+				Arrays.asList(new String[] { "1012832469V956223^NI^200M^USVHA^P", "796046489^PI^200BRLS^USVBA^A",
+						"600071516^PI^200CORP^USVBA^A", "1040626995^NI^200DOD^USDOD^A", "796046489^SS" }));
 		final String token = tokenResource.getToken(person);
 
 		final JwtAuthenticationToken authentication = new JwtAuthenticationToken(token);
@@ -103,18 +105,21 @@ public class JwtAuthenticationProviderTest {
 	}
 
 	/**
-	 * Test of method that validates PersonTraits in the Jwt token, of class JwtAuthenticationProvider.
+	 * Test of method that validates PersonTraits in the Jwt token, of class
+	 * JwtAuthenticationProvider.
 	 */
 	@Test
 	public void testIsPersonTraitsValid() {
 		PersonTraits person = new PersonTraits();
 		person.setFirstName("string");
 		assertTrue(JwtAuthenticationProvider.isPersonTraitsValid(person, new String[] { "firstName" }));
-		assertFalse(JwtAuthenticationProvider.isPersonTraitsValid(person, new String[] { "firstName", "assuranceLevel" }));
+		assertFalse(
+				JwtAuthenticationProvider.isPersonTraitsValid(person, new String[] { "firstName", "assuranceLevel" }));
 	}
 
 	/**
-	 * Test of method that validates PersonTraits in the Jwt token, of class JwtAuthenticationProvider.
+	 * Test of method that validates PersonTraits in the Jwt token, of class
+	 * JwtAuthenticationProvider.
 	 */
 	@Test
 	public void testIsPersonTraitsValidInvocationException() {
@@ -125,7 +130,8 @@ public class JwtAuthenticationProviderTest {
 	}
 
 	/**
-	 * Test of method that validates PersonTraits in the Jwt token, of class JwtAuthenticationProvider.
+	 * Test of method that validates PersonTraits in the Jwt token, of class
+	 * JwtAuthenticationProvider.
 	 */
 	@Test
 	public void testIsPersonTraitsValidWithInvalidJwtParameter() {
@@ -133,24 +139,26 @@ public class JwtAuthenticationProviderTest {
 		person.setFirstName("string");
 		assertFalse(JwtAuthenticationProvider.isPersonTraitsValid(person, new String[] { "testText" }));
 	}
-	
+
 	/**
-	 * Test of retrieveUser method, of class JwtAuthenticationProvider.
+	 * Test of retrieveUser method for JwtAuthenticationException, of class
+	 * JwtAuthenticationProvider.
 	 */
-	@Test (expected = JwtAuthenticationException.class)
+	@Test(expected = JwtAuthenticationException.class)
 	public void testRetrieveUserWithReqParamException() {
 		final String username = "jdoe";
 		final Person person = new Person();
 		person.setFirstName("john");
 		person.setLastName("doe");
-		person.setCorrelationIds(Arrays.asList(new String[] { "1012832469V956223^NI^200M^USVHA^P", "796046489^PI^200BRLS^USVBA^A",
-				"600071516^PI^200CORP^USVBA^A", "1040626995^NI^200DOD^USDOD^A", "796046489^SS" }));
+		person.setCorrelationIds(
+				Arrays.asList(new String[] { "1012832469V956223^NI^200M^USVHA^P", "796046489^PI^200BRLS^USVBA^A",
+						"600071516^PI^200CORP^USVBA^A", "1040626995^NI^200DOD^USDOD^A", "796046489^SS" }));
 		final String token = tokenResource.getToken(person);
 
 		final JwtAuthenticationToken authentication = new JwtAuthenticationToken(token);
 		final JwtParser parser = new JwtParser(jwtAuthenticationProperties);
 		final JwtAuthenticationProvider instance = new JwtAuthenticationProvider(parser);
-		String[] jwtTokenRequiredParameterList = {"middleName"};
+		String[] jwtTokenRequiredParameterList = { "middleName" };
 		ReflectionTestUtils.setField(instance, "jwtTokenRequiredParameterList", jwtTokenRequiredParameterList);
 		final UserDetails result = instance.retrieveUser(username, authentication);
 		assertNotNull(result);


### PR DESCRIPTION
- JWT Token Required Parameter List wasn't enforcing and returning check for all the fields
- Message customized as shown `Invalid Token. Parameter(s) Missing. Required JWT parameters configured [CONFIGURED_LIST_GOES_HERE]`