### PR TITLE
AF-725# Implementation of the multiple API consumers through JWT

### DIFF
--- a/bip-framework-libraries/src/main/java/gov/va/bip/framework/security/jwt/JwtAuthenticationProperties.java
+++ b/bip-framework-libraries/src/main/java/gov/va/bip/framework/security/jwt/JwtAuthenticationProperties.java
@@ -1,5 +1,8 @@
 package gov.va.bip.framework.security.jwt;
 
+import java.util.Collections;
+import java.util.List;
+
 import org.springframework.boot.autoconfigure.security.SecurityProperties;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
@@ -17,6 +20,8 @@ public class JwtAuthenticationProperties {
 	private int expireInSeconds = 900;
 	private String[] filterProcessUrls = { "/api/**" };
 	private String[] excludeUrls = { "/**" };
+	/** List of inner class {@link JwtKeyPairs} configuration objects */
+	private List<JwtKeyPairs> keyPairs = Collections.emptyList();
 
 	public static final int AUTH_ORDER = SecurityProperties.BASIC_AUTH_ORDER - 2;
 	public static final int NO_AUTH_ORDER = AUTH_ORDER + 1;
@@ -145,6 +150,94 @@ public class JwtAuthenticationProperties {
 	 */
 	public void setExpireInSeconds(int expireInSeconds) {
 		this.expireInSeconds = expireInSeconds;
+	}
+	
+	/**
+	 * List of inner class {@link JwtKeyPairs} configuration objects.
+	 *
+	 * @return List of JwtKeyPairs objects
+	 */
+	public List<JwtKeyPairs> getKeyPairs() {
+		return keyPairs;
+	}
+	
+	/**
+	 * The inner class {@link JwtKeyPairs} configuration object.
+	 *
+	 * @param keyPairs the JWT key pairs
+	 */
+	public void setKeyPairs(final List<JwtKeyPairs> keyPairs) {
+		this.keyPairs = keyPairs;
+	}
+	
+	/**
+	 * Inner class to hold the secret and issuer pair
+	 * <p>
+	 * A list of JwtKeyPairs objects is populated from list entries in the application yaml
+	 * under {@code bip.framework.security.jwt.keyPairs}.
+	 *
+	 */
+	public static class JwtKeyPairs {
+		
+		/** The secret */
+		private String secret;
+
+		/** The issuer */
+		private String issuer;
+		
+		/**
+		 * Instantiates a new JWT key pair POJO.
+		 *
+		 */
+		public JwtKeyPairs() {
+		}
+		
+		/**
+		 * Instantiates a new JWT key pair POJO.
+		 *
+		 * @param secret the secret
+		 * @param issuer the issuer
+		 */
+		public JwtKeyPairs(String secret, String issuer) {
+			setSecret(secret);
+			setIssuer(issuer);
+		}
+
+		/**
+		 * Secret for JWT token.
+		 *
+		 * @return String
+		 */
+		public String getSecret() {
+			return secret;
+		}
+
+		/**
+		 * Secret for JWT token.
+		 *
+		 * @param name
+		 */
+		public void setSecret(final String secret) {
+			this.secret = secret;
+		}
+
+		/**
+		 * Issuer name for JWT token.
+		 *
+		 * @return Long
+		 */
+		public String getIssuer() {
+			return issuer;
+		}
+
+		/**
+		 * Issuer name for JWT token.
+		 *
+		 * @param issuer
+		 */
+		public void setIssuer(final String issuer) {
+			this.issuer = issuer;
+		}
 	}
 
 }

--- a/bip-framework-libraries/src/main/java/gov/va/bip/framework/security/jwt/TokenResource.java
+++ b/bip-framework-libraries/src/main/java/gov/va/bip/framework/security/jwt/TokenResource.java
@@ -1,5 +1,7 @@
 package gov.va.bip.framework.security.jwt;
 
+import java.util.List;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.MediaType;
@@ -9,6 +11,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
+import gov.va.bip.framework.security.jwt.JwtAuthenticationProperties.JwtKeyPairs;
 import gov.va.bip.framework.security.model.Person;
 import gov.va.bip.framework.security.util.GenerateToken;
 import gov.va.bip.framework.swagger.SwaggerResponseMessages;
@@ -47,11 +50,16 @@ public class TokenResource implements SwaggerResponseMessages {
 			@ApiResponse(code = 400, message = MESSAGE_400), @ApiResponse(code = 500, message = MESSAGE_500) })
 	public String getToken(
 			@ApiParam(value = API_PARAM_GETTOKEN_PERSON, required = true) @RequestBody final Person person) {
-		// @ApiModel(description="Identity information for the authenticated
-		// user.")
-		return GenerateToken.generateJwt(person, jwtAuthenticationProperties.getExpireInSeconds(),
-				jwtAuthenticationProperties.getSecret(), jwtAuthenticationProperties.getIssuer(),
-				jwtTokenRequiredParameterList);
+		final List<JwtKeyPairs> jwtKeyPairs = jwtAuthenticationProperties.getKeyPairs();
+		if (jwtKeyPairs != null && !jwtKeyPairs.isEmpty()) {
+			return GenerateToken.generateJwt(person, jwtAuthenticationProperties.getExpireInSeconds(),
+					jwtKeyPairs.get(0).getSecret(), jwtKeyPairs.get(0).getIssuer(),
+					jwtTokenRequiredParameterList);
+		} else {
+			return GenerateToken.generateJwt(person, jwtAuthenticationProperties.getExpireInSeconds(),
+					jwtAuthenticationProperties.getSecret(), jwtAuthenticationProperties.getIssuer(),
+					jwtTokenRequiredParameterList);
+		}
 	}
 
 	/**

--- a/bip-framework-libraries/src/main/java/gov/va/bip/framework/security/jwt/TokenResource.java
+++ b/bip-framework-libraries/src/main/java/gov/va/bip/framework/security/jwt/TokenResource.java
@@ -43,18 +43,18 @@ public class TokenResource implements SwaggerResponseMessages {
 	@Value("${bip.framework.security.jwt.validation.required-parameters:}")
 	private String[] jwtTokenRequiredParameterList;
 
-	@PostMapping(value = { "/token", "/api/{v?.*}/token" }, consumes = {
-			MediaType.ALL_VALUE }, produces = { MediaType.ALL_VALUE })
+	@PostMapping(value = { "/token", "/api/{v?.*}/token" }, consumes = { MediaType.ALL_VALUE }, produces = {
+			MediaType.ALL_VALUE })
 	@ApiOperation(value = API_OPERATION_VALUE, notes = API_OPERATION_NOTES)
 	@ApiResponses(value = { @ApiResponse(code = 200, message = MESSAGE_200),
 			@ApiResponse(code = 400, message = MESSAGE_400), @ApiResponse(code = 500, message = MESSAGE_500) })
 	public String getToken(
 			@ApiParam(value = API_PARAM_GETTOKEN_PERSON, required = true) @RequestBody final Person person) {
 		final List<JwtKeyPairs> jwtKeyPairs = jwtAuthenticationProperties.getKeyPairs();
-		if (jwtKeyPairs != null && !jwtKeyPairs.isEmpty()) {
+		if (jwtKeyPairs != null && !jwtKeyPairs.isEmpty() && jwtKeyPairs.get(0) != null
+				&& jwtKeyPairs.get(0).getSecret() != null && jwtKeyPairs.get(0).getIssuer() != null) {
 			return GenerateToken.generateJwt(person, jwtAuthenticationProperties.getExpireInSeconds(),
-					jwtKeyPairs.get(0).getSecret(), jwtKeyPairs.get(0).getIssuer(),
-					jwtTokenRequiredParameterList);
+					jwtKeyPairs.get(0).getSecret(), jwtKeyPairs.get(0).getIssuer(), jwtTokenRequiredParameterList);
 		} else {
 			return GenerateToken.generateJwt(person, jwtAuthenticationProperties.getExpireInSeconds(),
 					jwtAuthenticationProperties.getSecret(), jwtAuthenticationProperties.getIssuer(),

--- a/bip-framework-libraries/src/test/java/gov/va/bip/framework/security/jwt/JwtAuthenticationFilterTest.java
+++ b/bip-framework-libraries/src/test/java/gov/va/bip/framework/security/jwt/JwtAuthenticationFilterTest.java
@@ -45,7 +45,9 @@ public class JwtAuthenticationFilterTest {
 	public void testNormalOperation() throws Exception {
 		/* MAKE SURE PROPERTIES ARE CORRECT */
 		final String secret = "secret";
+		final String issuer = "Vets.gov";
 		properties.setSecret(secret);
+		properties.setIssuer(issuer);
 		properties.setFilterProcessUrls(new String[] { "/**" });
 		properties.setExcludeUrls(new String[] { "/v2/api-docs/**", "/configuration/ui/**", "/swagger-resources/**",
 				"/configuration/security/**", "/swagger-ui.html", "/webjars/**", "/**/token", "/**/swagger/error-keys.html" });

--- a/bip-framework-libraries/src/test/java/gov/va/bip/framework/security/jwt/JwtAuthenticationPropertiesTest.java
+++ b/bip-framework-libraries/src/test/java/gov/va/bip/framework/security/jwt/JwtAuthenticationPropertiesTest.java
@@ -3,6 +3,10 @@ package gov.va.bip.framework.security.jwt;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -10,7 +14,6 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 import gov.va.bip.framework.security.config.BipSecurityTestConfig;
-import gov.va.bip.framework.security.jwt.JwtAuthenticationProperties;
 
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration(classes = BipSecurityTestConfig.class)
@@ -111,8 +114,8 @@ public class JwtAuthenticationPropertiesTest {
 	@Test
 	public void testSetIssuer() {
 		String issuer = "Issuer2.gov";
-		jwtAuthenticationProperties.setSecret(issuer);
-		assertTrue(issuer.equals(jwtAuthenticationProperties.getSecret()));
+		jwtAuthenticationProperties.setIssuer(issuer);
+		assertTrue(issuer.equals(jwtAuthenticationProperties.getIssuer()));
 	}
 
 	/**
@@ -154,6 +157,19 @@ public class JwtAuthenticationPropertiesTest {
 		String[] excludeUrls = { "http://localhost:8762/api/bip-reference-person/swagger-ui.html" };
 		jwtAuthenticationProperties.setExcludeUrls(excludeUrls);
 		assertTrue(jwtAuthenticationProperties.getExcludeUrls().length > 0);
+	}
+	
+	/**
+	 * Test of setSecret method, of class JwtAuthenticationProperties.
+	 */
+	@Test
+	public void testSetJwtKeyPairs() {
+		List<JwtAuthenticationProperties.JwtKeyPairs> listKeyPairs = new ArrayList<JwtAuthenticationProperties.JwtKeyPairs>();
+		listKeyPairs.add(new JwtAuthenticationProperties.JwtKeyPairs("secret1","issuer1"));
+		jwtAuthenticationProperties.setKeyPairs(listKeyPairs);
+		assertTrue("secret1".equals(jwtAuthenticationProperties.getKeyPairs().get(0).getSecret()));
+		assertTrue("issuer1".equals(jwtAuthenticationProperties.getKeyPairs().get(0).getIssuer()));
+		jwtAuthenticationProperties.setKeyPairs(Collections.emptyList());
 	}
 
 }

--- a/bip-framework-libraries/src/test/java/gov/va/bip/framework/security/jwt/JwtParserTest.java
+++ b/bip-framework-libraries/src/test/java/gov/va/bip/framework/security/jwt/JwtParserTest.java
@@ -14,6 +14,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
@@ -27,6 +28,7 @@ import io.jsonwebtoken.SignatureException;
 
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration(classes = BipSecurityTestConfig.class)
+@DirtiesContext
 public class JwtParserTest {
 
 	private static final Date BIRTH_DATE = Calendar.getInstance().getTime();

--- a/bip-framework-libraries/src/test/java/gov/va/bip/framework/security/jwt/JwtParserTest.java
+++ b/bip-framework-libraries/src/test/java/gov/va/bip/framework/security/jwt/JwtParserTest.java
@@ -13,30 +13,19 @@ import java.util.List;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.test.annotation.DirtiesContext;
-import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 import gov.va.bip.framework.security.PersonTraits;
-import gov.va.bip.framework.security.config.BipSecurityTestConfig;
-import gov.va.bip.framework.security.jwt.JwtAuthenticationProperties;
-import gov.va.bip.framework.security.jwt.JwtParser;
 import gov.va.bip.framework.security.model.Person;
 import gov.va.bip.framework.security.util.GenerateToken;
 import io.jsonwebtoken.SignatureException;
 
 @RunWith(SpringJUnit4ClassRunner.class)
-@ContextConfiguration(classes = BipSecurityTestConfig.class)
-@DirtiesContext
 public class JwtParserTest {
 
 	private static final Date BIRTH_DATE = Calendar.getInstance().getTime();
 
 	private String token;
-
-	@Autowired
-	private JwtAuthenticationProperties jwtAuthenticationProperties;
 
 	private JwtParser jwtParser;
 
@@ -44,6 +33,7 @@ public class JwtParserTest {
 
 	@Before
 	public void setup() {
+		JwtAuthenticationProperties jwtAuthenticationProperties = new JwtAuthenticationProperties();
 		jwtParser = new JwtParser(jwtAuthenticationProperties);
 		Person person = new Person();
 		person.setFirstName("FN");
@@ -94,9 +84,9 @@ public class JwtParserTest {
 	
 	@Test
 	public void parseJwtTestEmptyPair() {
-		JwtAuthenticationProperties jwtJwtAuthPropertiesEmptyPair = new JwtAuthenticationProperties();
-		jwtJwtAuthPropertiesEmptyPair.setKeyPairs(Collections.emptyList());
-		JwtParser jwtParserNoPair = new JwtParser(jwtJwtAuthPropertiesEmptyPair);
+		JwtAuthenticationProperties jwtAuthPropertiesEmptyPair = new JwtAuthenticationProperties();
+		jwtAuthPropertiesEmptyPair.setKeyPairs(Collections.emptyList());
+		JwtParser jwtParserNoPair = new JwtParser(jwtAuthPropertiesEmptyPair);
 		PersonTraits personTraits = jwtParserNoPair.parseJwt(token);
 		assertNotNull(personTraits.getUser());
 	}

--- a/bip-framework-libraries/src/test/java/gov/va/bip/framework/security/jwt/JwtParserTest.java
+++ b/bip-framework-libraries/src/test/java/gov/va/bip/framework/security/jwt/JwtParserTest.java
@@ -4,8 +4,12 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 import java.text.SimpleDateFormat;
+import java.util.ArrayList;
 import java.util.Calendar;
+import java.util.Collections;
 import java.util.Date;
+import java.util.List;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -19,6 +23,7 @@ import gov.va.bip.framework.security.jwt.JwtAuthenticationProperties;
 import gov.va.bip.framework.security.jwt.JwtParser;
 import gov.va.bip.framework.security.model.Person;
 import gov.va.bip.framework.security.util.GenerateToken;
+import io.jsonwebtoken.SignatureException;
 
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration(classes = BipSecurityTestConfig.class)
@@ -76,6 +81,54 @@ public class JwtParserTest {
 		assertNotNull(personTraits.getEmail());
 		assertTrue("validemail@testdomain.com".equals(personTraits.getEmail()));
 		assertNotNull(personTraits.getUser());
+	}
+	
+	@Test
+	public void parseJwtTestNoPair() {
+		JwtParser jwtParserNoPair = new JwtParser(new JwtAuthenticationProperties());
+		PersonTraits personTraits = jwtParserNoPair.parseJwt(token);
+		assertNotNull(personTraits.getUser());
+	}
+	
+	@Test
+	public void parseJwtTestEmptyPair() {
+		JwtAuthenticationProperties jwtJwtAuthPropertiesEmptyPair = new JwtAuthenticationProperties();
+		jwtJwtAuthPropertiesEmptyPair.setKeyPairs(Collections.emptyList());
+		JwtParser jwtParserNoPair = new JwtParser(jwtJwtAuthPropertiesEmptyPair);
+		PersonTraits personTraits = jwtParserNoPair.parseJwt(token);
+		assertNotNull(personTraits.getUser());
+	}
+	
+	@Test
+	public void parseJwtTestWithValidPair() {
+		JwtAuthenticationProperties jwtAuthPropertiesWithPair = new JwtAuthenticationProperties();
+		List<JwtAuthenticationProperties.JwtKeyPairs> listKeyPairs = new ArrayList<JwtAuthenticationProperties.JwtKeyPairs>();
+		listKeyPairs.add(new JwtAuthenticationProperties.JwtKeyPairs("secret","Vets.gov"));
+		jwtAuthPropertiesWithPair.setKeyPairs(listKeyPairs);
+		JwtParser jwtParserWithPair = new JwtParser(jwtAuthPropertiesWithPair);
+		PersonTraits personTraits = jwtParserWithPair.parseJwt(token);
+		assertNotNull(personTraits.getUser());
+	}
+	
+	@Test(expected = SignatureException.class)
+	public void parseJwtTestWithInvalidPair() {
+		JwtAuthenticationProperties jwtAuthPropertiesWithPair = new JwtAuthenticationProperties();
+		List<JwtAuthenticationProperties.JwtKeyPairs> listKeyPairs = new ArrayList<JwtAuthenticationProperties.JwtKeyPairs>();
+		listKeyPairs.add(new JwtAuthenticationProperties.JwtKeyPairs("secret1","Vets.gov"));
+		jwtAuthPropertiesWithPair.setKeyPairs(listKeyPairs);
+		JwtParser jwtParserWithPair = new JwtParser(jwtAuthPropertiesWithPair);
+		jwtParserWithPair.parseJwt(token);
+	}
+	
+	@Test
+	public void parseJwtTestWithInvalidValidPair() {
+		JwtAuthenticationProperties jwtAuthPropertiesWithPair = new JwtAuthenticationProperties();
+		List<JwtAuthenticationProperties.JwtKeyPairs> listKeyPairs = new ArrayList<JwtAuthenticationProperties.JwtKeyPairs>();
+		listKeyPairs.add(new JwtAuthenticationProperties.JwtKeyPairs("secret1","Vets.gov"));
+		listKeyPairs.add(new JwtAuthenticationProperties.JwtKeyPairs("secret","Vets.gov"));
+		jwtAuthPropertiesWithPair.setKeyPairs(listKeyPairs);
+		JwtParser jwtParserWithPair = new JwtParser(jwtAuthPropertiesWithPair);
+		jwtParserWithPair.parseJwt(token);
 	}
 
 }

--- a/bip-framework-libraries/src/test/java/gov/va/bip/framework/security/jwt/JwtParserTest.java
+++ b/bip-framework-libraries/src/test/java/gov/va/bip/framework/security/jwt/JwtParserTest.java
@@ -120,7 +120,8 @@ public class JwtParserTest {
 		listKeyPairs.add(new JwtAuthenticationProperties.JwtKeyPairs("secret","Vets.gov"));
 		jwtAuthPropertiesWithPair.setKeyPairs(listKeyPairs);
 		JwtParser jwtParserWithPair = new JwtParser(jwtAuthPropertiesWithPair);
-		jwtParserWithPair.parseJwt(token);
+		PersonTraits personTraits = jwtParserWithPair.parseJwt(token);
+		assertNotNull(personTraits.getUser());
 	}
 
 }

--- a/bip-framework-libraries/src/test/java/gov/va/bip/framework/security/jwt/TokenResourceTest.java
+++ b/bip-framework-libraries/src/test/java/gov/va/bip/framework/security/jwt/TokenResourceTest.java
@@ -8,45 +8,31 @@ import java.util.List;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.Spy;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.security.authentication.AuthenticationProvider;
 import org.springframework.test.annotation.DirtiesContext;
-import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.web.bind.WebDataBinder;
 
-import gov.va.bip.framework.security.config.BipSecurityTestConfig;
-import gov.va.bip.framework.security.jwt.JwtAuthenticationProperties;
-import gov.va.bip.framework.security.jwt.TokenResource;
 import gov.va.bip.framework.security.model.Person;
 
 @RunWith(SpringJUnit4ClassRunner.class)
-@ContextConfiguration(classes = BipSecurityTestConfig.class)
 @DirtiesContext
 public class TokenResourceTest {
-
-	@Autowired
-	TokenResource tokenResource;
-
-	@Spy
-	JwtAuthenticationProperties properties;
-
-	@Autowired
-	AuthenticationProvider provider;
 
 	/**
 	 * Test of getToken method, of class TokenResource.
 	 */
 	@Test
 	public void testGetToken() {
+		TokenResource tokenResource = new TokenResource();
+		JwtAuthenticationProperties jwtAuthenticationProperties = new JwtAuthenticationProperties();
 		Person person = new Person();
 		person.setFirstName("john");
 		person.setLastName("doe");
 		String[] arrayOfCorrelationIds = { "1012832469V956223^NI^200M^USVHA^P", "796046489^PI^200BRLS^USVBA^A",
 				"600071516^PI^200CORP^USVBA^A", "1040626995^NI^200DOD^USDOD^A", "796046489^SS" };
 		person.setCorrelationIds(Arrays.asList(arrayOfCorrelationIds));
+		ReflectionTestUtils.setField(tokenResource, "jwtAuthenticationProperties", jwtAuthenticationProperties);
 		String result = tokenResource.getToken(person);
 		assertTrue(result.length() > 0);
 
@@ -57,16 +43,18 @@ public class TokenResourceTest {
 	 */
 	@Test
 	public void testGetTokenValidJwtKeyPair() {
+		TokenResource tokenResource = new TokenResource();
+		JwtAuthenticationProperties jwtAuthenticationProperties = new JwtAuthenticationProperties();
 		List<JwtAuthenticationProperties.JwtKeyPairs> listKeyPairs = new ArrayList<JwtAuthenticationProperties.JwtKeyPairs>();
 		listKeyPairs.add(new JwtAuthenticationProperties.JwtKeyPairs("secret","Vets.gov"));
-		properties.setKeyPairs(listKeyPairs);
+		jwtAuthenticationProperties.setKeyPairs(listKeyPairs);
 		Person person = new Person();
 		person.setFirstName("john");
 		person.setLastName("doe");
 		String[] arrayOfCorrelationIds = { "1012832469V956223^NI^200M^USVHA^P", "796046489^PI^200BRLS^USVBA^A",
 				"600071516^PI^200CORP^USVBA^A", "1040626995^NI^200DOD^USDOD^A", "796046489^SS" };
 		person.setCorrelationIds(Arrays.asList(arrayOfCorrelationIds));
-		ReflectionTestUtils.setField(tokenResource, "jwtAuthenticationProperties", properties);
+		ReflectionTestUtils.setField(tokenResource, "jwtAuthenticationProperties", jwtAuthenticationProperties);
 		String result = tokenResource.getToken(person);
 		assertTrue(result.length() > 0);
 
@@ -77,14 +65,16 @@ public class TokenResourceTest {
 	 */
 	@Test
 	public void testGetTokenEmptyJwtKeyPair() {
-		properties.setKeyPairs(null);
+		TokenResource tokenResource = new TokenResource();
+		JwtAuthenticationProperties jwtAuthenticationProperties = new JwtAuthenticationProperties();
+		jwtAuthenticationProperties.setKeyPairs(null);
 		Person person = new Person();
 		person.setFirstName("john");
 		person.setLastName("doe");
 		String[] arrayOfCorrelationIds = { "1012832469V956223^NI^200M^USVHA^P", "796046489^PI^200BRLS^USVBA^A",
 				"600071516^PI^200CORP^USVBA^A", "1040626995^NI^200DOD^USDOD^A", "796046489^SS" };
 		person.setCorrelationIds(Arrays.asList(arrayOfCorrelationIds));
-		ReflectionTestUtils.setField(tokenResource, "jwtAuthenticationProperties", properties);
+		ReflectionTestUtils.setField(tokenResource, "jwtAuthenticationProperties", jwtAuthenticationProperties);
 		String result = tokenResource.getToken(person);
 		assertTrue(result.length() > 0);
 

--- a/bip-framework-libraries/src/test/java/gov/va/bip/framework/security/jwt/TokenResourceTest.java
+++ b/bip-framework-libraries/src/test/java/gov/va/bip/framework/security/jwt/TokenResourceTest.java
@@ -2,14 +2,19 @@ package gov.va.bip.framework.security.jwt;
 
 import static org.junit.Assert.assertTrue;
 
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Spy;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.authentication.AuthenticationProvider;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.web.bind.WebDataBinder;
 
 import gov.va.bip.framework.security.config.BipSecurityTestConfig;
@@ -22,9 +27,10 @@ import gov.va.bip.framework.security.model.Person;
 public class TokenResourceTest {
 
 	@Autowired
+	@InjectMocks
 	TokenResource tokenResource;
 
-	@Autowired
+	@Spy
 	JwtAuthenticationProperties properties;
 
 	@Autowired
@@ -41,6 +47,44 @@ public class TokenResourceTest {
 		String[] arrayOfCorrelationIds = { "1012832469V956223^NI^200M^USVHA^P", "796046489^PI^200BRLS^USVBA^A",
 				"600071516^PI^200CORP^USVBA^A", "1040626995^NI^200DOD^USDOD^A", "796046489^SS" };
 		person.setCorrelationIds(Arrays.asList(arrayOfCorrelationIds));
+		String result = tokenResource.getToken(person);
+		assertTrue(result.length() > 0);
+
+	}
+	
+	/**
+	 * Test of getToken method, of class TokenResource.
+	 */
+	@Test
+	public void testGetTokenValidJwtKeyPair() {
+		List<JwtAuthenticationProperties.JwtKeyPairs> listKeyPairs = new ArrayList<JwtAuthenticationProperties.JwtKeyPairs>();
+		listKeyPairs.add(new JwtAuthenticationProperties.JwtKeyPairs("secret","Vets.gov"));
+		properties.setKeyPairs(listKeyPairs);
+		Person person = new Person();
+		person.setFirstName("john");
+		person.setLastName("doe");
+		String[] arrayOfCorrelationIds = { "1012832469V956223^NI^200M^USVHA^P", "796046489^PI^200BRLS^USVBA^A",
+				"600071516^PI^200CORP^USVBA^A", "1040626995^NI^200DOD^USDOD^A", "796046489^SS" };
+		person.setCorrelationIds(Arrays.asList(arrayOfCorrelationIds));
+		ReflectionTestUtils.setField(tokenResource, "jwtAuthenticationProperties", properties);
+		String result = tokenResource.getToken(person);
+		assertTrue(result.length() > 0);
+
+	}
+	
+	/**
+	 * Test of getToken method, of class TokenResource.
+	 */
+	@Test
+	public void testGetTokenEmptyJwtKeyPair() {
+		properties.setKeyPairs(null);
+		Person person = new Person();
+		person.setFirstName("john");
+		person.setLastName("doe");
+		String[] arrayOfCorrelationIds = { "1012832469V956223^NI^200M^USVHA^P", "796046489^PI^200BRLS^USVBA^A",
+				"600071516^PI^200CORP^USVBA^A", "1040626995^NI^200DOD^USDOD^A", "796046489^SS" };
+		person.setCorrelationIds(Arrays.asList(arrayOfCorrelationIds));
+		ReflectionTestUtils.setField(tokenResource, "jwtAuthenticationProperties", properties);
 		String result = tokenResource.getToken(person);
 		assertTrue(result.length() > 0);
 

--- a/bip-framework-libraries/src/test/java/gov/va/bip/framework/security/jwt/TokenResourceTest.java
+++ b/bip-framework-libraries/src/test/java/gov/va/bip/framework/security/jwt/TokenResourceTest.java
@@ -40,6 +40,8 @@ public class TokenResourceTest {
 	
 	/**
 	 * Test of getToken method, of class TokenResource.
+	 * 
+	 * To test JwtKeyPairs with valid secret and issuer
 	 */
 	@Test
 	public void testGetTokenValidJwtKeyPair() {
@@ -62,12 +64,86 @@ public class TokenResourceTest {
 	
 	/**
 	 * Test of getToken method, of class TokenResource.
+	 * 
+	 * To test JwtKeyPairs as null
 	 */
 	@Test
-	public void testGetTokenEmptyJwtKeyPair() {
+	public void testGetTokenNullJwtKeyPair() {
 		TokenResource tokenResource = new TokenResource();
 		JwtAuthenticationProperties jwtAuthenticationProperties = new JwtAuthenticationProperties();
 		jwtAuthenticationProperties.setKeyPairs(null);
+		Person person = new Person();
+		person.setFirstName("john");
+		person.setLastName("doe");
+		String[] arrayOfCorrelationIds = { "1012832469V956223^NI^200M^USVHA^P", "796046489^PI^200BRLS^USVBA^A",
+				"600071516^PI^200CORP^USVBA^A", "1040626995^NI^200DOD^USDOD^A", "796046489^SS" };
+		person.setCorrelationIds(Arrays.asList(arrayOfCorrelationIds));
+		ReflectionTestUtils.setField(tokenResource, "jwtAuthenticationProperties", jwtAuthenticationProperties);
+		String result = tokenResource.getToken(person);
+		assertTrue(result.length() > 0);
+
+	}
+	
+	/**
+	 * Test of getToken method, of class TokenResource.
+	 * 
+	 * To test JwtKeyPairs with null element in the key pair
+	 */
+	@Test
+	public void testGetTokenNullElementJwtKeyPair() {
+		TokenResource tokenResource = new TokenResource();
+		JwtAuthenticationProperties jwtAuthenticationProperties = new JwtAuthenticationProperties();
+		List<JwtAuthenticationProperties.JwtKeyPairs> listKeyPairs = new ArrayList<JwtAuthenticationProperties.JwtKeyPairs>();
+		listKeyPairs.add(null);
+		jwtAuthenticationProperties.setKeyPairs(listKeyPairs);
+		Person person = new Person();
+		person.setFirstName("john");
+		person.setLastName("doe");
+		String[] arrayOfCorrelationIds = { "1012832469V956223^NI^200M^USVHA^P", "796046489^PI^200BRLS^USVBA^A",
+				"600071516^PI^200CORP^USVBA^A", "1040626995^NI^200DOD^USDOD^A", "796046489^SS" };
+		person.setCorrelationIds(Arrays.asList(arrayOfCorrelationIds));
+		ReflectionTestUtils.setField(tokenResource, "jwtAuthenticationProperties", jwtAuthenticationProperties);
+		String result = tokenResource.getToken(person);
+		assertTrue(result.length() > 0);
+
+	}
+	
+	/**
+	 * Test of getToken method, of class TokenResource.
+	 * 
+	 * To test JwtKeyPairs with null secret and valid issuer
+	 */
+	@Test
+	public void testGetTokenNullSecretJwtKeyPair() {
+		TokenResource tokenResource = new TokenResource();
+		JwtAuthenticationProperties jwtAuthenticationProperties = new JwtAuthenticationProperties();
+		List<JwtAuthenticationProperties.JwtKeyPairs> listKeyPairs = new ArrayList<JwtAuthenticationProperties.JwtKeyPairs>();
+		listKeyPairs.add(new JwtAuthenticationProperties.JwtKeyPairs(null,"Vets.gov"));
+		jwtAuthenticationProperties.setKeyPairs(listKeyPairs);
+		Person person = new Person();
+		person.setFirstName("john");
+		person.setLastName("doe");
+		String[] arrayOfCorrelationIds = { "1012832469V956223^NI^200M^USVHA^P", "796046489^PI^200BRLS^USVBA^A",
+				"600071516^PI^200CORP^USVBA^A", "1040626995^NI^200DOD^USDOD^A", "796046489^SS" };
+		person.setCorrelationIds(Arrays.asList(arrayOfCorrelationIds));
+		ReflectionTestUtils.setField(tokenResource, "jwtAuthenticationProperties", jwtAuthenticationProperties);
+		String result = tokenResource.getToken(person);
+		assertTrue(result.length() > 0);
+
+	}
+	
+	/**
+	 * Test of getToken method, of class TokenResource.
+	 * 
+	 * To test JwtKeyPairs with valid secret and null issuer
+	 */
+	@Test
+	public void testGetTokenNullIssuerJwtKeyPair() {
+		TokenResource tokenResource = new TokenResource();
+		JwtAuthenticationProperties jwtAuthenticationProperties = new JwtAuthenticationProperties();
+		List<JwtAuthenticationProperties.JwtKeyPairs> listKeyPairs = new ArrayList<JwtAuthenticationProperties.JwtKeyPairs>();
+		listKeyPairs.add(new JwtAuthenticationProperties.JwtKeyPairs("secret",null));
+		jwtAuthenticationProperties.setKeyPairs(listKeyPairs);
 		Person person = new Person();
 		person.setFirstName("john");
 		person.setLastName("doe");

--- a/bip-framework-libraries/src/test/java/gov/va/bip/framework/security/jwt/TokenResourceTest.java
+++ b/bip-framework-libraries/src/test/java/gov/va/bip/framework/security/jwt/TokenResourceTest.java
@@ -8,10 +8,10 @@ import java.util.List;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.InjectMocks;
 import org.mockito.Spy;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.authentication.AuthenticationProvider;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.test.util.ReflectionTestUtils;
@@ -24,10 +24,10 @@ import gov.va.bip.framework.security.model.Person;
 
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration(classes = BipSecurityTestConfig.class)
+@DirtiesContext
 public class TokenResourceTest {
 
 	@Autowired
-	@InjectMocks
 	TokenResource tokenResource;
 
 	@Spy

--- a/bip-framework-parentpom/pom.xml
+++ b/bip-framework-parentpom/pom.xml
@@ -1181,7 +1181,7 @@
 							<replacements>
 								<replacement>
 									<token>"https://petstore.swagger.io/v2/swagger.json"</token>
-									<value>"/openapi.json"</value>
+									<value>"openapi.json"</value>
 								</replacement>
 							</replacements>
 						</configuration>


### PR DESCRIPTION
1) New feature to support multiple consumers via bip.framework.security.jwt.keyPairs list of issuer and secret pairs
2) JWT token generation and parsing modifications
3) Added new property and static inner class inJwtAuthenticationProperties
4) Design Page: https://github.com/department-of-veterans-affairs/bip-framework/wiki/Design-for-Multiple-API-Consumers-using-JSON-Web-Token-(JWT)